### PR TITLE
Feedback updates

### DIFF
--- a/.sandbox/manifest.yaml
+++ b/.sandbox/manifest.yaml
@@ -2,8 +2,6 @@ hooks:
   build:
     cmd: |
       sudo apt-get install -y libgmp3-dev
-      gem install rails
-      sudo apt-get update
       sudo apt-get install -y mysql-client libmysqlclient-dev
-      echo "export MYSQL_DB=\"mysql\"" >> ~/.bashrc
-      echo "export MYSQL_PASS=\"batman\"" >> ~/.bashrc
+      sudo apt-get update
+      gem install rails

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Rails with MySQL template for Cloud Sandbox
 
-This is a skeleton [ruby on rails](https://rubyonrails.org/) application template created on a basic [App](https://crafting.readme.io/docs/app-spec) configuration in [Cloud Sandbox](https://crafting.readme.io/docs/introduction). 
+This is a template [Ruby on Rails](https://rubyonrails.org/) skeleton application created on a basic [App](https://crafting.readme.io/docs/app-spec) configuration in [Cloud Sandbox](https://crafting.readme.io/docs/introduction). 
 
 ## Getting Started
 
@@ -16,7 +16,7 @@ The general workflow when developing in Cloud Sandbox involves:
 
 ### 2. Creating Sandbox
 
-Once App has been configured, you can create a sandbox using either the Web UI, or using the command line tool:
+Once App has been configured, you can create a sandbox using either the Web UI, or through the command line tool:
 
 ```
 cs sandbox create
@@ -24,7 +24,9 @@ cs sandbox create
 
 ### 3. Developing with Sandbox
 
-After creating a sandbox, you can start developing in the workspace using any of the Web UI or command line tools. The [docs](https://crafting.readme.io/docs/development-in-sandbox) contain more information for working with a sandbox. This template was generated following the steps [below](https://github.com/crafting-dev/template-ruby-rails#steps-to-recreate-template).
+After creating a sandbox, you can start developing in the workspace using any of the Web UI or command line tools. The [docs](https://crafting.readme.io/docs/development-in-sandbox) contain more information for working with a sandbox. 
+
+This template was generated following the steps [below](https://github.com/crafting-dev/template-ruby-rails#steps-to-recreate-template).
 
 ## Caveat
 
@@ -48,12 +50,12 @@ spec:
   - http:
       routes:
       - backend:
-          port: localhost
+          port: http
           target: ruby-rails
         path_prefix: /
-    name: base
+    name: app
   services:
-  - description: Ruby/Rails template
+  - description: Ruby on Rails with MySQL template
     name: ruby-rails
     workspace:
       checkouts:
@@ -65,16 +67,11 @@ spec:
           git: git@github.com:crafting-dev/template-ruby-rails.git
       packages:
       - name: ruby
-        version: 2.7.2
+        version: ~2.7
       - name: nodejs
-        version: 16.9.1
-      port_forward_rules:
-      - local: "3306"
-        remote:
-          port: mysql
-          target: mysql
+        version: ~16
       ports:
-      - name: localhost
+      - name: http
         port: 3000
         protocol: HTTP/TCP
   - managed_service:
@@ -99,15 +96,10 @@ cs sandbox create
 
 Install necessary packages and gems before creating a new rails app in the workspace.
 
-1. `sudo apt-get install libgmp3-dev`
-2. `gem install rails`
+1. `sudo apt-get install -y libgmp3-dev`
+2. `sudo apt-get install -y mysql-client libmysqlclient-dev`
 3. `sudo apt-get update`
-4. `sudo apt-get install mysql-client libmysqlclient-dev`
-
-Make mysql credentials set in App configurations available as environment variables:
-
-1. `echo "export MYSQL_DB=\"mysql\"" >> ~/.bashrc`
-2. `echo "export MYSQL_PASS=\"batman\"" >> ~/.bashrc`
+4. `gem install rails`
 
 Create new rails app:
 
@@ -115,7 +107,7 @@ Create new rails app:
 rails new . -d mysql
 ```
 
-Update `config/database.yml` to use the already set mysql credentials:
+Update `config/database.yml`:
 
 ```yaml
 default: &default
@@ -123,17 +115,22 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: <%= ENV['MYSQL_PASS'] %>
-  host: <%= ENV['MYSQL_DB'] %>
+  password: batman # Use an environment variable in a real app setting
+  host: <%= ENV['MYSQL_SERVICE_HOST'] %>
 
 development:
   <<: *default
-  database: <%= ENV['MYSQL_DB'] %>
+  database: mysql
   
 production:
   <<: *default
   url: <%= ENV['MY_APP_DATABASE_URL'] %>
 ```
+
+*NOTE 1*: Sandbox supports standard service injection, where the environment variables `MYSQL_SERVICE_HOST` and `MYSQL_SERVICE_PORT` are already populated. See [environment variables](https://crafting.readme.io/docs/environment-variables) for more details.
+
+*NOTE 2*: For `production.url`, you can specify the connection url environment variable explicitly. Read [Configuring a database](https://guides.rubyonrails.org/configuring.html#configuring-a-database) for a full overview on how database connection configuration can be specified.
+
 
 Then start a new rails server:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ spec:
           - content: ""
         path: src/template-ruby-rails
         repo:
-          git: git@github.com:crafting-dev/template-ruby-rails.git
+          git: https://github.com/crafting-dev/template-ruby-rails.git
       packages:
       - name: ruby
         version: ~2.7

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,12 +14,12 @@ default: &default
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password: <%= ENV['MYSQL_PASS'] %>
-  host: <%= ENV['MYSQL_DB'] %>
+  password: batman
+  host: <%= ENV['MYSQL_SERVICE_HOST'] %>
 
 development:
   <<: *default
-  database: <%= ENV['MYSQL_DB'] %>
+  database: mysql
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".


### PR DESCRIPTION
This PR makes the following changes:

1. `.sandbox/manifest.yaml`: Group `apt-get` commands together. Move `gem install rails` to bottom. Remove environment variables.
2. `App configuration`: Remove `port_forward_rules`
3. `App configuration`: Rename endpoint to `app` instead of `base`
4. `App configuration`: Rename service port to `http` instead of `localhost`
5. `App configuration`: Set ruby version to `~2.7` and node to `~16` to avoid locking down package versions
6. `config/database.yml`: Update `default.host` and `default.password`. Use `MYSQL_SERVICE_HOST` instead of creating new envs.
7. `readme.md`: Update docs to reflect all changes, and add some more notes.

